### PR TITLE
Signal observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ client.on('network', signal => console.log(signal));
 
 Messages sent as responses to a request are not emitted as signals.
 
+It is also possible to work with signals in a promisifed way by using observers:
+
+```javascript
+// Register observer for all network events
+const observer client.observe(['network:*']);
+// Start the network
+client.network.start({
+  graph: 'my-graph',
+})
+  .then(() => {
+    // Receive all network signals on stopped, or failure with errors
+    return observer.until(['network:stopped'], ['network:error', 'network:processerror']);
+  });
+```
+
+## Debugging
+
+It is possible to see the internal workings of the library by setting the `DEBUG` environment variable to one or multiple of the following:
+
+* `fbp-client:adapter:signal`: Signals received by the runtime
+* `fbp-client:adapter:request`: Requests sent to the runtime
+* `fbp-client:adapter:response`: Responses received by the runtime
+* `fbp-client:observer`: Observer results
+* `fbp-client:observer:ignored`: Signals ignored by an observer
+
 ## Changes
 
 * 0.1.0 (2018-03-22)

--- a/lib/adapter/0_x.js
+++ b/lib/adapter/0_x.js
@@ -1,4 +1,7 @@
 const validate = require('../validate')();
+const debugSignal = require('debug')('fbp-client:adapter:signal');
+const debugRequest = require('debug')('fbp-client:adapter:request');
+const debugResponse = require('debug')('fbp-client:adapter:response');
 
 class Adapter {
   constructor(client, version) {
@@ -17,6 +20,7 @@ class Adapter {
         this.listener(message);
         return;
       }
+      debugSignal(`${message.protocol}:${message.command}`);
       // If there is no listener, treat it as signal
       validate(`/${message.protocol}/output/${message.command}`, message)
         .then(() => this.client.signal(message), err => this.client.protocolError(err));
@@ -90,6 +94,7 @@ class Adapter {
             .then(() => {
               if (!isAcceptedResponse(message)) {
                 // Unrelated message, treat as signal
+                debugSignal(`${message.protocol}:${message.command}`);
                 this.client.signal(message);
                 return;
               }
@@ -98,6 +103,7 @@ class Adapter {
                 clearTimeout(timeout);
                 timeout = null;
               }
+              debugResponse(`${message.protocol}:${message.command} for request ${protocol}:${command}`);
               if (message.command === 'error') {
                 const err = new Error(message.payload.message);
                 err.stack = message.payload.stack;
@@ -126,6 +132,7 @@ class Adapter {
               this.tick();
             });
         };
+        debugRequest(`${protocol}:${command}`);
         this.client.transport.send(protocol, command, payload);
 
         if (protocol === 'component') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,6 +3,7 @@ const { EventEmitter } = require('events');
 const schemas = require('fbp-protocol/schema/schemas');
 const { timedPromise, addressToProtocol } = require('./utils');
 const validate = require('./validate')();
+const observe = require('./observe');
 const adapter0x = require('./adapter/0_x');
 
 class FbpClient extends EventEmitter {
@@ -68,6 +69,10 @@ class FbpClient extends EventEmitter {
       });
       this.transport.disconnect();
     });
+  }
+
+  observe(events) {
+    return observe(this, events);
   }
 
   signal(message) {

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -6,6 +6,9 @@ function stringMatches(string, matcher) {
 }
 
 function signalMatches(signal, signatures) {
+  if (typeof signatures === 'function') {
+    return signatures(signal);
+  }
   const matched = signatures.filter((signature) => {
     const [protocol, command] = signature.split(':');
     return (stringMatches(signal.protocol, protocol) && stringMatches(signal.command, command));
@@ -42,19 +45,19 @@ class Observer {
     this.listener = null;
   }
 
-  until(successEvents, failureEvents) {
+  until(success, failure) {
     return new Promise((resolve, reject) => {
       // Check signals received until now
       for (let i = 0; i < this.signals.length; i += 1) {
         const signal = this.signals[i];
-        if (signalMatches(signal, failureEvents)) {
+        if (signalMatches(signal, failure)) {
           // TODO: Convert to error
           reject(this.signals.slice(0, i + 1));
           this.unsubscribe();
           this.signals = [];
           return;
         }
-        if (signalMatches(signal, successEvents)) {
+        if (signalMatches(signal, success)) {
           resolve(this.signals.slice(0, i + 1));
           this.unsubscribe();
           this.signals = [];
@@ -64,7 +67,7 @@ class Observer {
 
       // See if the signal arrives later
       const listener = (signal) => {
-        if (signalMatches(signal, failureEvents)) {
+        if (signalMatches(signal, failure)) {
           // TODO: Convert to error
           reject(this.signals.slice(0));
           this.unsubscribe();
@@ -72,7 +75,7 @@ class Observer {
           this.signals = [];
           return;
         }
-        if (signalMatches(signal, successEvents)) {
+        if (signalMatches(signal, success)) {
           resolve(this.signals.slice(0));
           this.unsubscribe();
           this.client.removeListener('signal', listener);

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -1,3 +1,6 @@
+const debugObserver = require('debug')('fbp-client:observer');
+const debugObserverIgnored = require('debug')('fbp-client:observer:ignored');
+
 function stringMatches(string, matcher) {
   if (matcher === '*') {
     return true;
@@ -41,8 +44,10 @@ class Observer {
   subscribe(events) {
     this.listener = (signal) => {
       if (!signalMatches(signal, events)) {
+        debugObserverIgnored(`${signal.protocol}:${signal.command}`);
         return;
       }
+      debugObserver(`Observed ${signal.protocol}:${signal.command}`);
       this.signals.push(signal);
     };
     this.client.on('signal', this.listener);
@@ -63,16 +68,18 @@ class Observer {
         const signal = this.signals[i];
         if (signalMatches(signal, failure)) {
           const err = signalToError(signal);
+          debugObserver(`Failed with ${signal.protocol}:${signal.command}`);
           err.signals = this.signals.slice(0, i + 1);
-          reject(err);
           this.unsubscribe();
           this.signals = [];
+          reject(err);
           return;
         }
         if (signalMatches(signal, success)) {
-          resolve(this.signals.slice(0, i + 1));
+          debugObserver(`Succeeded with ${signal.protocol}:${signal.command}`);
           this.unsubscribe();
           this.signals = [];
+          resolve(this.signals.slice(0, i + 1));
           return;
         }
       }
@@ -80,19 +87,22 @@ class Observer {
       // See if the signal arrives later
       const listener = (signal) => {
         if (signalMatches(signal, failure)) {
+          debugObserver(`Failed with ${signal.protocol}:${signal.command}`);
           const err = signalToError(signal);
           err.signals = this.signals.slice(0);
-          reject(err);
           this.unsubscribe();
           this.client.removeListener('signal', listener);
           this.signals = [];
+          reject(err);
           return;
         }
         if (signalMatches(signal, success)) {
-          resolve(this.signals.slice(0));
+          debugObserver(`Succeeded with ${signal.protocol}:${signal.command}`);
+          const signals = this.signals.slice(0);
           this.unsubscribe();
           this.client.removeListener('signal', listener);
           this.signals = [];
+          resolve(signals);
         }
       };
       this.client.on('signal', listener);

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -1,0 +1,87 @@
+function stringMatches(string, matcher) {
+  if (matcher === '*') {
+    return true;
+  }
+  return (string === matcher);
+}
+
+function signalMatches(signal, signatures) {
+  const matched = signatures.filter((signature) => {
+    const [protocol, command] = signature.split(':');
+    return (stringMatches(signal.protocol, protocol) && stringMatches(signal.command, command));
+  });
+  if (matched.length > 0) {
+    return true;
+  }
+  return false;
+}
+
+class Observer {
+  constructor(client, events) {
+    this.client = client;
+    this.signals = [];
+    this.listener = null;
+    this.subscribe(events);
+  }
+
+  subscribe(events) {
+    this.listener = (signal) => {
+      if (!signalMatches(signal, events)) {
+        return;
+      }
+      this.signals.push(signal);
+    };
+    this.client.on('signal', this.listener);
+  }
+
+  unsubscribe() {
+    if (!this.listener) {
+      return;
+    }
+    this.client.removeListener('signal', this.listener);
+    this.listener = null;
+  }
+
+  until(successEvents, failureEvents) {
+    return new Promise((resolve, reject) => {
+      // Check signals received until now
+      for (let i = 0; i < this.signals.length; i += 1) {
+        const signal = this.signals[i];
+        if (signalMatches(signal, failureEvents)) {
+          // TODO: Convert to error
+          reject(this.signals.slice(0, i + 1));
+          this.unsubscribe();
+          this.signals = [];
+          return;
+        }
+        if (signalMatches(signal, successEvents)) {
+          resolve(this.signals.slice(0, i + 1));
+          this.unsubscribe();
+          this.signals = [];
+          return;
+        }
+      }
+
+      // See if the signal arrives later
+      const listener = (signal) => {
+        if (signalMatches(signal, failureEvents)) {
+          // TODO: Convert to error
+          reject(this.signals.slice(0));
+          this.unsubscribe();
+          this.client.removeListener('signal', listener);
+          this.signals = [];
+          return;
+        }
+        if (signalMatches(signal, successEvents)) {
+          resolve(this.signals.slice(0));
+          this.unsubscribe();
+          this.client.removeListener('signal', listener);
+          this.signals = [];
+        }
+      };
+      this.client.on('signal', listener);
+    });
+  }
+}
+
+module.exports = (client, events) => new Observer(client, events);

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -77,9 +77,10 @@ class Observer {
         }
         if (signalMatches(signal, success)) {
           debugObserver(`Succeeded with ${signal.protocol}:${signal.command}`);
+          const signals = this.signals.slice(0, i + 1);
           this.unsubscribe();
           this.signals = [];
-          resolve(this.signals.slice(0, i + 1));
+          resolve(signals);
           return;
         }
       }

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -19,6 +19,17 @@ function signalMatches(signal, signatures) {
   return false;
 }
 
+function signalToError(signal) {
+  const signature = `${signal.protocol}:${signal.command}`;
+  const errorMessage = signal.payload.error || `Unexpected ${signature} message`;
+  const err = new Error(errorMessage);
+  err.signature = signature;
+  if (signal.payload.stack) {
+    err.stack = signal.payload.stack;
+  }
+  return err;
+}
+
 class Observer {
   constructor(client, events) {
     this.client = client;
@@ -51,8 +62,9 @@ class Observer {
       for (let i = 0; i < this.signals.length; i += 1) {
         const signal = this.signals[i];
         if (signalMatches(signal, failure)) {
-          // TODO: Convert to error
-          reject(this.signals.slice(0, i + 1));
+          const err = signalToError(signal);
+          err.signals = this.signals.slice(0, i + 1);
+          reject(err);
           this.unsubscribe();
           this.signals = [];
           return;
@@ -68,8 +80,9 @@ class Observer {
       // See if the signal arrives later
       const listener = (signal) => {
         if (signalMatches(signal, failure)) {
-          // TODO: Convert to error
-          reject(this.signals.slice(0));
+          const err = signalToError(signal);
+          err.signals = this.signals.slice(0);
+          reject(err);
           this.unsubscribe();
           this.client.removeListener('signal', listener);
           this.signals = [];

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/flowbased/fbp-client#readme",
   "dependencies": {
     "ajv": "^5.0.0",
+    "debug": "^3.1.0",
     "fbp-protocol": "^0.9.1",
     "fbp-protocol-client": "^0.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fbp-graph": "^0.3.1",
     "mocha": "^5.0.4",
     "noflo-core": "^0.5.0",
-    "noflo-nodejs": "^0.10.0",
+    "noflo-nodejs": "^0.10.1",
     "nyc": "^11.6.0"
   },
   "nyc": {

--- a/spec/noflo-nodejs.js
+++ b/spec/noflo-nodejs.js
@@ -16,6 +16,7 @@ describe('FBP Client with noflo-nodejs', () => {
       '--host=localhost',
       '--port=3570',
       '--secret=fbp-client',
+      '--open=false',
       `--base-dir=${baseDir}`,
     ]);
     nofloNodejs.stdout.on('data', (data) => {

--- a/spec/noflo-nodejs.js
+++ b/spec/noflo-nodejs.js
@@ -170,6 +170,28 @@ exports.getComponent = () => noflo.asComponent(plusOne);
       });
     });
   });
+  describe('when creating graph with missing components', () => {
+    it('should be possible to send a graph', () => {
+      const graph = new fbpGraph('one-plus-two');
+      graph.addNode('repeat', 'core/Repeat');
+      graph.addNode('plus', 'foo/PlusTwo');
+      graph.addNode('output', 'core/Output');
+      graph.addEdge('repeat', 'out', 'plus', 'val');
+      graph.addEdge('plus', 'out', 'output', 'in');
+      graph.addInitial(1, 'repeat', 'in');
+      return client.protocol.graph.send(graph);
+    });
+    it('should be possible to start the graph', () => {
+      return client.protocol.network.start({
+        graph: 'one-plus-two',
+      })
+        .then(() => { throw new Error('Unexpected success') })
+        .catch((err) => {
+          expect(err).to.be.an('error');
+          expect(err.message).to.contain('Component foo/PlusTwo not available');
+        });
+    });
+  });
   describe('when creating graph with exported ports', () => {
     let observer = null;
     it('should be possible to send a graph', () => {

--- a/spec/noflo-nodejs.js
+++ b/spec/noflo-nodejs.js
@@ -124,7 +124,7 @@ exports.getComponent = () => noflo.asComponent(plusOne);
       graph.addEdge('repeat', 'out', 'plus', 'val');
       graph.addEdge('plus', 'out', 'output', 'in');
       graph.addInitial(1, 'repeat', 'in');
-      return client.protocol.graph.send(graph);
+      return client.protocol.graph.send(graph, true);
     });
     it('should be possible to start the graph', () => {
       const observer = client.observe(['network:*']);
@@ -179,7 +179,7 @@ exports.getComponent = () => noflo.asComponent(plusOne);
       graph.addEdge('repeat', 'out', 'plus', 'val');
       graph.addEdge('plus', 'out', 'output', 'in');
       graph.addInitial(1, 'repeat', 'in');
-      return client.protocol.graph.send(graph);
+      return client.protocol.graph.send(graph, true);
     });
     it('should be possible to start the graph', () => {
       return client.protocol.network.start({
@@ -229,7 +229,7 @@ exports.getComponent = () => {
       graph.addEdge('repeat', 'out', 'plus', 'in');
       graph.addEdge('plus', 'out', 'output', 'in');
       graph.addInitial(1, 'repeat', 'in');
-      return client.protocol.graph.send(graph);
+      return client.protocol.graph.send(graph, true);
     });
     it('should be possible to start the graph', () => {
       observer = client.observe((signal) => signal.protocol === 'network' && signal.payload.graph === 'one-plus-three');


### PR DESCRIPTION
This adds a nicer promisified way to collect and utilize signals from the runtime.

For example, observe a network instance, you can:

```javascript
const observer = client.observe(['network:*']);
client.network.start({
  graph: 'foo',
})
  .then(() => observer.until(['network:stopped'], ['network:error', 'network:processerror']));
```

With this, if the network finishes without errors, you'll get all network events in the resolved promise.

If there was a network or process error, then the promise will be rejected with an error corresponding to the matched failure event. The error object will also contain the signals received.