### PR TITLE
Add option to skip validation

### DIFF
--- a/lib/adapter/0_x.js
+++ b/lib/adapter/0_x.js
@@ -1,4 +1,3 @@
-const validate = require('../validate')();
 const debugSignal = require('debug')('fbp-client:adapter:signal');
 const debugRequest = require('debug')('fbp-client:adapter:request');
 const debugResponse = require('debug')('fbp-client:adapter:response');
@@ -22,7 +21,7 @@ class Adapter {
       }
       debugSignal(`${message.protocol}:${message.command}`);
       // If there is no listener, treat it as signal
-      validate(`/${message.protocol}/output/${message.command}`, message)
+      this.client.validate(`/${message.protocol}/output/${message.command}`, message)
         .then(() => this.client.canReceive(message.protocol, message.command))
         .then(() => this.client.signal(message), err => this.client.protocolError(err));
     };
@@ -91,7 +90,7 @@ class Adapter {
       const execute = () => {
         let timeout = null;
         this.listener = (message) => {
-          validate(`/${message.protocol}/output/${message.command}`, message)
+          this.client.validate(`/${message.protocol}/output/${message.command}`, message)
             .then(() => this.client.canReceive(message.protocol, message.command))
             .then(() => {
               if (!isAcceptedResponse(message)) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,21 @@ class FbpClient extends EventEmitter {
     if (!this.options.skipPermissions) {
       this.options.skipPermissions = false;
     }
+    if (!this.options.skipValidation) {
+      this.options.skipValidation = false;
+    }
     this.prepareCommands();
+  }
+
+  validate(schema, message) {
+    return validate(schema, message)
+      .catch((e) => {
+        if (this.options.skipValidation) {
+          this.protocolError(e);
+          return Promise.resolve(message);
+        }
+        return Promise.reject(e);
+      });
   }
 
   isConnected() {
@@ -44,7 +58,7 @@ class FbpClient extends EventEmitter {
           return;
         }
         this.transport.removeListener('error', onError);
-        validate('/runtime/output/runtime', message)
+        this.validate('/runtime/output/runtime', message)
           .then(() => {
             this.prepareAdapter(message.payload.version);
             resolve(this.definition);
@@ -137,7 +151,7 @@ class FbpClient extends EventEmitter {
         commands[command] = (payload = {}) => {
           const withSecret = payload;
           withSecret.secret = this.definition.secret;
-          return validate(`/${protocol}/${schemas[protocol].input[command].id}`, {
+          return this.validate(`/${protocol}/${schemas[protocol].input[command].id}`, {
             protocol,
             command,
             payload: withSecret,

--- a/lib/observe.js
+++ b/lib/observe.js
@@ -68,11 +68,13 @@ class Observer {
       debugObserver(`Observed ${signal.protocol}:${signal.command}`);
       this.signals.push(signal);
     };
-    this.errorListener = (err) => {
-      this.protocolErrors.push(err);
-    };
     this.client.on('signal', this.listener);
-    this.client.on('protocolError', this.errorListener);
+    if (!this.client.options.skipValidation) {
+      this.errorListener = (err) => {
+        this.protocolErrors.push(err);
+      };
+      this.client.on('protocolError', this.errorListener);
+    }
   }
 
   unsubscribe() {
@@ -130,7 +132,9 @@ class Observer {
           err.signals = this.signals.slice(0);
           this.unsubscribe();
           this.client.removeListener('signal', listener);
-          this.client.removeListener('protocolError', errorListener);
+          if (!this.client.options.skipValidation) {
+            this.client.removeListener('protocolError', errorListener);
+          }
           this.signals = [];
           reject(err);
           return;
@@ -140,7 +144,9 @@ class Observer {
           const signals = this.signals.slice(0);
           this.unsubscribe();
           this.client.removeListener('signal', listener);
-          this.client.removeListener('protocolError', errorListener);
+          if (!this.client.options.skipValidation) {
+            this.client.removeListener('protocolError', errorListener);
+          }
           this.signals = [];
           resolve(signals);
         }
@@ -152,12 +158,16 @@ class Observer {
         error.signals = this.signals.slice(0);
         this.unsubscribe();
         this.client.removeListener('signal', listener);
-        this.client.removeListener('protocolError', errorListener);
+        if (!this.client.options.skipValidation) {
+          this.client.removeListener('protocolError', errorListener);
+        }
         this.signals = [];
         reject(error);
       };
       this.client.on('signal', listener);
-      this.client.on('protocolError', errorListener);
+      if (!this.client.options.skipValidation) {
+        this.client.on('protocolError', errorListener);
+      }
     });
   }
 }

--- a/spec/dummy.js
+++ b/spec/dummy.js
@@ -103,6 +103,27 @@ describe('FBP Client with dummy runtime', () => {
         });
     });
   });
+  describe('with invalid runtime payload and skipValidation=true', () => {
+    it('should be able to connect', () => {
+      runtime.once('message', (msg) => {
+        if (msg.protocol === 'runtime' && msg.command === 'getruntime') {
+          runtime.send('runtime', 'runtime', {
+            type: 'foo',
+            version: '0.4',
+            baz: 'bar',
+          });
+        }
+      });
+      return fbpClient({
+        address: 'ws://localhost:3671',
+        secret: '',
+      }, {
+        skipValidation: true
+      })
+        .then((c) => c.connect().then(() => Promise.resolve(c)))
+        .then((c) => c.disconnect())
+    });
+  });
   describe('with valid 0.6 runtime and full capabilities', () => {
     let client = null;
     it('should be able to connect', () => {


### PR DESCRIPTION
With `skipValidation: true` validation errors are emitted via `protocolErrors` but don't cause failures in requests or observers.